### PR TITLE
Update Arena sets for 24.0

### DIFF
--- a/config.json
+++ b/config.json
@@ -14,18 +14,18 @@
 	"arena": {
 		"current_sets": [
 			"CORE",
-			"BOOMSDAY",
-			"DRAGONS",
-			"THE_BARRENS",
-			"STORMWIND",
-			"ALTERAC_VALLEY",
-			"THE_SUNKEN_CITY",
-			"TAVERNS_OF_TIME"
+			"KARA",
+			"ULDUM",
+			"TROLL",
+			"SCHOLOMANCE",
+			"DARKMOON_FAIRE",
+			"REVENDRETH"
 		],
 		"banned_secrets": []
 	},
 	"pvpdr": {
 		"current_sets": [
+			"REVENDRETH",
 			"ALTERAC_VALLEY",
 			"STORMWIND",
 			"WAILING_CAVERNS",


### PR DESCRIPTION
As per https://hearthstone.blizzard.com/en-us/news/23831405/24-0-patch-notes:

- Core
- One Night in Karazhan
- Saviors of Uldum
- Rastakahn’s Rumble
- Scholomance Academy
- Madness at the Darkmoon Faire
- Murder at Castle Nathria

See also HearthSim/HSReplay.net#1126.